### PR TITLE
handle escaped @ symbol fixes Apple AddressBook problems

### DIFF
--- a/user_external/lib/imap.php
+++ b/user_external/lib/imap.php
@@ -46,6 +46,12 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			return false;
 		}
 
+		// Replace escaped @ symbol in uid (which is a mail address)
+		// but only if there is no @ symbol and if there is a %40 inside the uid
+		if (!(strpos($uid, '@') !== false) && (strpos($uid, '%40') !== false)) {
+			$uid = str_replace("%40","@",$uid);
+		}
+		
  		// Check if we only want logins from ONE domain and strip the domain part from UID		
  		if($this->domain != '') {
  			$pieces = explode('@', $uid);


### PR DESCRIPTION
Hi there,

the Apple AddressBook has troubles to login since NextCloud 12.0.0

fix nextcloud/contacts#233

It's because it escapes the @ symbol with %40.

This will replace a escaped @ symbol %40, but only if there is no other @ Symbol present