### PR TITLE
Fix inappropriate SQL-quoting in imap.php

### DIFF
--- a/user_external/lib/imap.php
+++ b/user_external/lib/imap.php
@@ -52,11 +52,11 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			$uid = str_replace("%40","@",$uid);
 		}
 
-		$result = OC_DB::executeAudited(
-			'SELECT `userid` FROM `*PREFIX*preferences`'
-			. ' WHERE `appid` = "settings" AND `configkey` = "email" AND `configvalue` = ?',
-			array($uid)
-		);
+                $result = OC_DB::executeAudited(
+                        'SELECT `userid` FROM `*PREFIX*preferences` WHERE `appid`=? AND `configkey`=? AND `configvalue`=?',
+                        array('settings','email',$uid)
+                );
+
 		$users = array();
 		while ($row = $result->fetchRow()) {
 			$users[] = $row['userid'];


### PR DESCRIPTION
External user-authentification against IMAP-gateways:
[Commit f8fb4d9](https://github.com/nextcloud/apps/commit/f8fb4d98464254c037b330d4a17c9851b7bee823) broke compatibility with PostgreSQL due to inappropriate SQL-quoting.